### PR TITLE
Require pygame-ce instead of pygame

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,5 +20,5 @@ setup(
     ],
     packages=["pygame_textinput"],
     include_package_data=True,
-    install_requires=["pygame"],
+    install_requires=["pygame-ce"],
 )


### PR DESCRIPTION
As pygame-ce is much more actively developed than pygame I thought it would be a good idea to require pygame-ce instead of pygame.